### PR TITLE
Reduce scope of test prefix to only swift tests

### DIFF
--- a/lib/xctest_list.rb
+++ b/lib/xctest_list.rb
@@ -35,13 +35,13 @@ class XCTestList
   end
 
   # find the Objective-C symbols in the bundle's binary
-  def self.objc_tests(xctest_bundle_path, test_prefix: "test")
+  def self.objc_tests(xctest_bundle_path)
     tests = []
     objc_symbols_command_output_tempfile = Tempfile.new(File.basename(xctest_bundle_path) + "objc")
     system("nm -U '#{binary_path(xctest_bundle_path)}' > '#{objc_symbols_command_output_tempfile.path}'")
     tests = []
     File.foreach(objc_symbols_command_output_tempfile.path) do |line|
-      regex = / t -\[(?<testclass>\w+) (?<testmethod>#{test_prefix}\w*)\]/
+      regex = / t -\[(?<testclass>\w+) (?<testmethod>test\w*)\]/
       if (matches = regex.match(line))
         tests << "#{matches[:testclass]}/#{matches[:testmethod]}"
       end
@@ -49,27 +49,22 @@ class XCTestList
     tests
   end
 
-  # cleanup the Swift nm output to only provide the swift symbols
-  def self.swift_symbols(swift_symbols_cmd_output, test_prefix: "test")
-    swift_symbols_cmd_output.gsub(/^.* .* (.*)$/, '\1')
-  end
-
-  def self.swift_symbol_dump_command(xctest_binary_path, test_prefix: "test")
+  def self.swift_symbol_dump_command(xctest_binary_path, swift_test_prefix: "test")
     nm_version_string = `nm -version | head -n 1 | sed -E 's/Apple LLVM version ([0-9]+\.[0-9]+\.[0-9]+).*/\\1/'`.chomp
     if Gem::Version.new(nm_version_string) < Gem::Version.new('9.0.0')
       "nm -gU '#{xctest_binary_path}' | cut -d' ' -f3 | xcrun swift-demangle | grep -E '^\\S+\\.test[^.]+\\(\\)$' | sed 's/ () -> ()/()/'"
     else
-      "nm -gU '#{xctest_binary_path}' | cut -d' ' -f3 | xargs -s 131072 xcrun swift-demangle | cut -d' ' -f3 | grep -e '[\\.|_]'#{test_prefix}"
+      "nm -gU '#{xctest_binary_path}' | cut -d' ' -f3 | xargs -s 131072 xcrun swift-demangle | cut -d' ' -f3 | grep -e '[\\.|_]'#{swift_test_prefix}"
     end
   end
 
   # find the Swift symbols in the bundle's binary
-  def self.swift_tests(xctest_bundle_path, test_prefix: "test")
+  def self.swift_tests(xctest_bundle_path, swift_test_prefix: "test")
     swift_symbols_command_output_tempfile = Tempfile.new(File.basename(xctest_bundle_path) + "swift")
-    system("#{swift_symbol_dump_command(binary_path(xctest_bundle_path), test_prefix: test_prefix)}  > '#{swift_symbols_command_output_tempfile.path}'")
+    system("#{swift_symbol_dump_command(binary_path(xctest_bundle_path), swift_test_prefix: swift_test_prefix)}  > '#{swift_symbols_command_output_tempfile.path}'")
     tests = []
     File.foreach(swift_symbols_command_output_tempfile.path) do |line|
-      regex = /\w+\.(?<testclass>[^\.]+)\.(?<testmethod>#{test_prefix}[^\(]*)\(/
+      regex = /\w+\.(?<testclass>[^\.]+)\.(?<testmethod>#{swift_test_prefix}[^\(]*)\(/
       if /.*-\[.*\]/ !~ line && (matches = regex.match(line))
         tests << "#{matches[:testclass]}/#{matches[:testmethod]}"
       end
@@ -78,7 +73,7 @@ class XCTestList
   end
 
   # find the Objective-C and Swift tests in the binary's bundle
-  def self.tests(xctest_bundle_path, test_prefix: 'test')
-    objc_tests(xctest_bundle_path, test_prefix: test_prefix) | swift_tests(xctest_bundle_path, test_prefix: test_prefix)
+  def self.tests(xctest_bundle_path, swift_test_prefix: 'test')
+    objc_tests(xctest_bundle_path) | swift_tests(xctest_bundle_path, swift_test_prefix: swift_test_prefix)
   end
 end

--- a/spec/xctest_list_spec.rb
+++ b/spec/xctest_list_spec.rb
@@ -124,8 +124,8 @@ describe XCTestList do
 
     describe 'when given a special test prefix' do
       it 'finds swift 4 tests' do
-        parsed_tests = XCTestList.tests('./spec/fixtures/Swift4.2/AtomicBoyUITestsWithExtension.xctest', test_prefix: 'spec')
-        expect(parsed_tests).to eq(["AtomicBoyUITests/specExample2", "AtomicBoyUITests/specExample", "SwiftAtomicBoyUITests/specExample"])
+        parsed_tests = XCTestList.tests('./spec/fixtures/Swift4.2/AtomicBoyUITestsWithExtension.xctest', swift_test_prefix: 'spec')
+        expect(parsed_tests).to eq(["SwiftAtomicBoyUITests/specExample"])
       end
     end
 


### PR DESCRIPTION
Nimble, or other invocation style Objective-C tests cannot be found via their prefix as such tests actually transform the names of the tests to filenames plus line numbers.

